### PR TITLE
Make Updater a static class, have constructors call subscribe directly

### DIFF
--- a/src/main/java/frc/team449/Robot.java
+++ b/src/main/java/frc/team449/Robot.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.team449.javaMaps.FullMap;
 import frc.team449.other.Clock;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.Logger;
 import org.jetbrains.annotations.NotNull;
 
@@ -67,8 +68,8 @@ public class Robot extends TimedRobot {
       CameraServer.startAutomaticCapture();
     }
 
-    // Read sensors
-    this.robotMap.getUpdater().run();
+    // Read sensors and update caches
+    Updater.run();
 
     Logger.configureLoggingAndConfig(this.robotMap, false);
     Shuffleboard.setRecordingFileNameFormat("log-${time}");
@@ -85,7 +86,7 @@ public class Robot extends TimedRobot {
     // save current time
     Clock.updateTime();
     // Read sensors
-    this.robotMap.getUpdater().run();
+    Updater.run();
     // update shuffleboard
     Logger.updateEntries();
     // Run all commands. This is a WPILib thing you don't really have to worry about.

--- a/src/main/java/frc/team449/RobotMap.java
+++ b/src/main/java/frc/team449/RobotMap.java
@@ -24,9 +24,6 @@ public class RobotMap {
 
   @NotNull private final MotorContainer motors = MotorContainer.getInstance();
 
-  /** A runnable that updates cached variables. */
-  @NotNull private final Runnable updater;
-
   @NotNull private final CommandContainer commands;
 
   @SuppressWarnings("FieldCanBeLocal")
@@ -41,7 +38,6 @@ public class RobotMap {
    *
    * @param subsystems The robot's subsystems.
    * @param pdp The PDP
-   * @param updater A runnable that updates cached variables.
    * @param commands A container to hold all of the robot's commands.
    * @param useCameraServer Whether the camera server should be run. Defaults to false.
    */
@@ -50,11 +46,9 @@ public class RobotMap {
       @NotNull @JsonProperty(required = true) @JsonInclude(content = JsonInclude.Include.NON_NULL)
           final List<Subsystem> subsystems,
       @NotNull @JsonProperty(required = true) final PDP pdp,
-      @NotNull @JsonProperty(required = true) final Runnable updater,
       @NotNull @JsonProperty(required = true) final CommandContainer commands,
       @Nullable final List<GenericHID> joysticks,
       final boolean useCameraServer) {
-    this.updater = updater;
     this.pdp = pdp;
     this.useCameraServer = useCameraServer;
     this.subsystems = subsystems;
@@ -94,12 +88,6 @@ public class RobotMap {
       return null;
     }
     return this.commands.getRobotStartupCommand().iterator();
-  }
-
-  /** @return A runnable that updates cached variables. */
-  @NotNull
-  public Runnable getUpdater() {
-    return this.updater;
   }
 
   /** @return Whether the camera server should be run. */

--- a/src/main/java/frc/team449/drive/unidirectional/DriveUnidirectionalBase.java
+++ b/src/main/java/frc/team449/drive/unidirectional/DriveUnidirectionalBase.java
@@ -3,6 +3,7 @@ package frc.team449.drive.unidirectional;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.team449.generalInterfaces.DriveSettings;
+import frc.team449.other.Updater;
 import frc.team449.wrappers.WrappedMotor;
 import io.github.oblarg.oblog.Loggable;
 import org.jetbrains.annotations.NotNull;
@@ -35,6 +36,7 @@ public class DriveUnidirectionalBase extends SubsystemBase
     this.leftMaster = leftMaster;
     this.rightMaster = rightMaster;
     this.settings = settings;
+    Updater.subscribe(this);
   }
 
   @Override

--- a/src/main/java/frc/team449/drive/unidirectional/DriveUnidirectionalSimple.java
+++ b/src/main/java/frc/team449/drive/unidirectional/DriveUnidirectionalSimple.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.Loggable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -33,6 +34,7 @@ public class DriveUnidirectionalSimple extends SubsystemBase
       @NotNull @JsonProperty(required = true) final MotorController rightMotor) {
     this.leftMotor = leftMotor;
     this.rightMotor = rightMotor;
+    Updater.subscribe(this);
   }
 
   /**

--- a/src/main/java/frc/team449/generalInterfaces/updatable/Updatable.java
+++ b/src/main/java/frc/team449/generalInterfaces/updatable/Updatable.java
@@ -2,7 +2,11 @@ package frc.team449.generalInterfaces.updatable;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-/** An interface for any object that caches values. */
+/**
+ * An interface for any object that caches values. <br>
+ * IMPORTANT: If you implement Updatable, be sure to call {@code Updater.register(this)} in your
+ * constructor
+ */
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.CLASS,
     include = JsonTypeInfo.As.WRAPPER_OBJECT,

--- a/src/main/java/frc/team449/javaMaps/FullMap.java
+++ b/src/main/java/frc/team449/javaMaps/FullMap.java
@@ -26,7 +26,6 @@ import frc.team449.oi.unidirectional.arcade.OIArcadeWithDPad;
 import frc.team449.other.Debouncer;
 import frc.team449.other.DefaultCommand;
 import frc.team449.other.FollowerUtils;
-import frc.team449.other.Updater;
 import frc.team449.wrappers.AHRS;
 import frc.team449.wrappers.PDP;
 import frc.team449.wrappers.RumbleableJoystick;
@@ -199,8 +198,6 @@ public class FullMap {
     // PUT YOUR SUBSYSTEM IN HERE AFTER INITIALIZING IT
     var subsystems = List.<Subsystem>of(drive, cargo, climber);
 
-    var updater = new Updater(List.of(pdp, navx));
-
     // Button bindings here
 
     // Take in balls but don't shoot
@@ -239,6 +236,6 @@ public class FullMap {
         new CommandContainer(
             robotStartupCommands, autoStartupCommands, teleopStartupCommands, testStartupCommands);
 
-    return new RobotMap(subsystems, pdp, updater, allCommands, joysticks, false);
+    return new RobotMap(subsystems, pdp, allCommands, joysticks, false);
   }
 }

--- a/src/main/java/frc/team449/multiSubsystem/BooleanSupplierUpdatable.java
+++ b/src/main/java/frc/team449/multiSubsystem/BooleanSupplierUpdatable.java
@@ -3,10 +3,12 @@ package frc.team449.multiSubsystem;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import frc.team449.generalInterfaces.updatable.Updatable;
-import java.util.Objects;
-import java.util.function.BooleanSupplier;
+import frc.team449.other.Updater;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
 
 /** Wraps a {@link BooleanSupplier} and only updates its result when told to. */
 public class BooleanSupplierUpdatable implements BooleanSupplier, Updatable {
@@ -24,6 +26,7 @@ public class BooleanSupplierUpdatable implements BooleanSupplier, Updatable {
       @Nullable final Boolean initialValue) {
     this.source = source;
     this.cachedValue = Objects.requireNonNullElseGet(initialValue, source::getAsBoolean);
+    Updater.subscribe(this);
   }
 
   /**

--- a/src/main/java/frc/team449/oi/fieldoriented/OIFieldOriented.java
+++ b/src/main/java/frc/team449/oi/fieldoriented/OIFieldOriented.java
@@ -2,6 +2,7 @@ package frc.team449.oi.fieldoriented;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import frc.team449.oi.OI;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.annotations.Log;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,6 +18,10 @@ public abstract class OIFieldOriented implements OI {
 
   /** The cached angular setpoint. */
   @Nullable private Double cachedTheta;
+
+  public OIFieldOriented() {
+    Updater.subscribe(this);
+  }
 
   /**
    * Get the absolute angle for the robot to move towards.

--- a/src/main/java/frc/team449/oi/throttles/ThrottleBasic.java
+++ b/src/main/java/frc/team449/oi/throttles/ThrottleBasic.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import edu.wpi.first.wpilibj.GenericHID;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.annotations.Log;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,6 +40,7 @@ public class ThrottleBasic implements Throttle {
     this.stick = stick;
     this.axis = axis;
     this.inverted = inverted;
+    Updater.subscribe(this);
   }
 
   /**

--- a/src/main/java/frc/team449/oi/throttles/ThrottleSum.java
+++ b/src/main/java/frc/team449/oi/throttles/ThrottleSum.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.annotations.Log;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,6 +27,7 @@ public class ThrottleSum implements Throttle {
   @JsonCreator
   public ThrottleSum(@NotNull @JsonProperty(required = true) Set<Throttle> throttles) {
     this.throttles = throttles;
+    Updater.subscribe(this);
   }
 
   /** Sums the throttles and returns their output */

--- a/src/main/java/frc/team449/oi/unidirectional/OIOutreach.java
+++ b/src/main/java/frc/team449/oi/unidirectional/OIOutreach.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import edu.wpi.first.wpilibj2.command.button.Button;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.annotations.Log;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,6 +44,7 @@ public class OIOutreach implements OIUnidirectional {
     this.overridingOI = overridingOI;
     this.overridenOI = overridenOI;
     this.button = stopButton;
+    Updater.subscribe(this);
   }
 
   /**

--- a/src/main/java/frc/team449/oi/unidirectional/arcade/OIArcade.java
+++ b/src/main/java/frc/team449/oi/unidirectional/arcade/OIArcade.java
@@ -3,6 +3,7 @@ package frc.team449.oi.unidirectional.arcade;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import frc.team449.oi.unidirectional.OIUnidirectional;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.annotations.Log;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -30,6 +31,7 @@ public abstract class OIArcade implements OIUnidirectional {
   @JsonCreator
   protected OIArcade(final boolean rescaleOutputs) {
     this.rescaleOutputs = rescaleOutputs;
+    Updater.subscribe(this);
   }
 
   /**

--- a/src/main/java/frc/team449/oi/unidirectional/tank/OITank.java
+++ b/src/main/java/frc/team449/oi/unidirectional/tank/OITank.java
@@ -2,6 +2,7 @@ package frc.team449.oi.unidirectional.tank;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import frc.team449.oi.unidirectional.OIUnidirectional;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.annotations.Log;
 
 /** A tank-style dual joystick OI. */
@@ -16,6 +17,10 @@ public abstract class OITank implements OIUnidirectional {
 
   /** Cached forwards and rotational output. */
   private double[] fwdRotOutputCached;
+
+  public OITank() {
+    Updater.subscribe(this);
+  }
 
   /**
    * Get the throttle for the left side of the drive.

--- a/src/main/java/frc/team449/other/Updater.java
+++ b/src/main/java/frc/team449/other/Updater.java
@@ -1,54 +1,30 @@
 package frc.team449.other;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import frc.team449.generalInterfaces.updatable.Updatable;
-import java.util.ArrayList;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
-/** A Runnable for updating cached variables. */
-@JsonIdentityInfo(generator = ObjectIdGenerators.StringIdGenerator.class)
-public class Updater implements Runnable {
+import java.util.HashSet;
+import java.util.Set;
 
-  /** Default instance that is run whenever any instance is run. */
-  private static final Updater defaultInstance = new Updater(new ArrayList<>());
+/**
+ * A class for updating cached variables. Run the {@link Updater#run()} method in {@link
+ * frc.team449.Robot#teleopPeriodic()}
+ */
+public final class Updater {
+
   /** The objects to update. */
-  @NotNull private final List<Updatable> updatables;
+  @NotNull private static final Set<Updatable> updatables = new HashSet<>();
 
-  /**
-   * Default constructor
-   *
-   * @param updatables The objects to update.
-   */
-  public Updater(@NotNull @JsonProperty(required = true) final List<Updatable> updatables) {
-    this.updatables = updatables;
-  }
+  private Updater() {}
 
-  /** Subscribes the specified updatable to being updated. */
-  public static void subscribe(final Updatable updatable) {
-    defaultInstance.updatables.add(updatable);
-  }
-
-  /**
-   * Constructs an updatable that also calls {@link Updater#run()} on the default updatable instance
-   * whenever it is run.
-   *
-   * @param updatables The objects to update.
-   */
-  @JsonCreator
-  public static Updater subscribe(
-      @NotNull @JsonProperty(required = true) final List<Updatable> updatables) {
-    defaultInstance.updatables.addAll(updatables);
-    return defaultInstance;
+  /** Subscribes the specified updatables to being updated. */
+  public static void subscribe(Updatable updatable) {
+    updatables.add(updatable);
   }
 
   /** Update all the updatables. */
-  @Override
-  public void run() {
-    for (final Updatable updatable : this.updatables) {
+  public static void run() {
+    for (var updatable : updatables) {
       updatable.update();
     }
   }

--- a/src/main/java/frc/team449/wrappers/AHRS.java
+++ b/src/main/java/frc/team449/wrappers/AHRS.java
@@ -1,17 +1,16 @@
 package frc.team449.wrappers;
 
-import static com.kauailabs.navx.frc.AHRS.SerialDataType.kProcessedData;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.SerialPort;
 import frc.team449.generalInterfaces.updatable.Updatable;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.Loggable;
 import io.github.oblarg.oblog.annotations.Log;
 import org.jetbrains.annotations.Contract;
+
+import static com.kauailabs.navx.frc.AHRS.SerialDataType.kProcessedData;
 
 /** An invertible wrapper for the NavX. */
 @JsonIdentityInfo(generator = ObjectIdGenerators.StringIdGenerator.class)
@@ -38,9 +37,7 @@ public class AHRS implements Updatable, Loggable {
    *     works.
    * @param invertYaw Whether or not to invert the yaw axis. Defaults to true.
    */
-  @JsonCreator
-  public AHRS(
-      @JsonProperty(required = true) final SerialPort.Port port, final Boolean invertYaw) {
+  public AHRS(SerialPort.Port port, final Boolean invertYaw) {
     if (port.equals(SerialPort.Port.kMXP)) {
       this.ahrs = new com.kauailabs.navx.frc.AHRS(SPI.Port.kMXP);
     } else {
@@ -52,6 +49,7 @@ public class AHRS implements Updatable, Loggable {
     } else {
       this.invertYaw = 1;
     }
+    Updater.subscribe(this);
   }
 
   /**

--- a/src/main/java/frc/team449/wrappers/MappedAnalogInput.java
+++ b/src/main/java/frc/team449/wrappers/MappedAnalogInput.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import edu.wpi.first.wpilibj.AnalogInput;
 import frc.team449.generalInterfaces.updatable.Updatable;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.Loggable;
 import io.github.oblarg.oblog.annotations.Log;
 
@@ -33,6 +34,7 @@ public class MappedAnalogInput extends AnalogInput implements Updatable, Loggabl
     super(port);
     setOversampleBits(oversampleBits);
     setAverageBits(averageBits);
+    Updater.subscribe(this);
   }
 
   /**

--- a/src/main/java/frc/team449/wrappers/PDP.java
+++ b/src/main/java/frc/team449/wrappers/PDP.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import edu.wpi.first.wpilibj.PowerDistribution;
 import frc.team449.components.RunningLinRegComponent;
 import frc.team449.generalInterfaces.updatable.Updatable;
+import frc.team449.other.Updater;
 import io.github.oblarg.oblog.Loggable;
 import io.github.oblarg.oblog.annotations.Log;
 import org.jetbrains.annotations.NotNull;
@@ -47,6 +48,7 @@ public class PDP implements Loggable, Updatable {
     this.temperature = 0;
     this.resistance = 0;
     this.unloadedVoltage = 0;
+    Updater.subscribe(this);
   }
 
   /**


### PR DESCRIPTION
This should keep us from leaving something out of `updatables` and causing dumb bugs, although it does introduce the possibility of someone making a new `Updatable` class and forgetting to do `Updater.subscribe(this)` inside its constructor.